### PR TITLE
Don't remove parentheses from conditions.

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -637,7 +637,7 @@ function OutputStream(options) {
         if (p instanceof AST_Call && p.expression === this)
             return true;
         // (a = foo) ? bar : baz
-        if (p instanceof AST_Conditional && p.condition === this)
+        if (p instanceof AST_Conditional && (p.condition === this || p.consequent === this))
             return true;
         // (a = foo)["prop"] —or— (a = foo).prop
         if (p instanceof AST_PropAccess && p.expression === this)


### PR DESCRIPTION
Added patch from https://github.com/mishoo/UglifyJS2/issues/1144#issuecomment-226990763. Fixes `Expected: :` error in ExtendScript.
